### PR TITLE
Allow /random endpoint to filter by search request

### DIFF
--- a/handlers_test.go
+++ b/handlers_test.go
@@ -1,10 +1,39 @@
 package main
 
 import (
+	"bytes"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"testing"
 )
+
+func mockEntry() []Entry {
+	return []Entry{
+		{
+			API:         "title",
+			Description: "description",
+			Auth:        "apiKey",
+			HTTPS:       false,
+			Cors:        "Cors",
+			Link:        "link",
+			Category:    "category",
+		},
+	}
+}
+
+func assertResponseValid(t *testing.T, body *bytes.Buffer, expected []Entry) {
+	var resp Entries
+	if err := json.NewDecoder(body).Decode(&resp); err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(resp.Entries, expected) {
+		t.Fatalf("handler returned wrong entry: got %v want %v",
+			resp.Entries, expected)
+	}
+
+}
 
 func TestHealthCheckHandler(t *testing.T) {
 	req, err := http.NewRequest("GET", "/health", nil)
@@ -30,12 +59,26 @@ func TestGetCategoriesHandler(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	rr := httptest.NewRecorder()
-	handler := healthCheckHandler()
-	handler.ServeHTTP(rr, req)
-	if status := rr.Code; status != http.StatusOK {
-		t.Errorf("handler returned wrong status code: got %v want %v",
-			status, http.StatusOK)
+	testCases := []struct {
+		categories   []string
+		expectedBody string
+	}{
+		{[]string{}, "[]\n"},
+		{[]string{"cat1"}, "[\"cat1\"]\n"},
+		{[]string{"cat1", "cat2", "cat3"}, "[\"cat1\",\"cat2\",\"cat3\"]\n"},
+	}
+	for _, tc := range testCases {
+		categories = tc.categories
+		rr := httptest.NewRecorder()
+		handler := getCategoriesHandler()
+		handler.ServeHTTP(rr, req)
+		if status := rr.Code; status != http.StatusOK {
+			t.Errorf("handler returned wrong status code: got %v want %v",
+				status, http.StatusOK)
+		}
+		if rr.Body.String() != tc.expectedBody {
+			t.Errorf("handler returned wrong body: got %q want %q", rr.Body, tc.expectedBody)
+		}
 	}
 }
 
@@ -44,17 +87,7 @@ func TestGetRandomHandler(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	apiList.Entries = []Entry{
-		{
-			API:         "title",
-			Description: "description",
-			Auth:        "apiKey",
-			HTTPS:       false,
-			Cors:        "Cors",
-			Link:        "link",
-			Category:    "category",
-		},
-	}
+	apiList.Entries = mockEntry()
 	rr := httptest.NewRecorder()
 	handler := getRandomHandler()
 	handler.ServeHTTP(rr, req)
@@ -62,6 +95,7 @@ func TestGetRandomHandler(t *testing.T) {
 		t.Errorf("handler returned wrong status code: got %v want %v",
 			status, http.StatusOK)
 	}
+	assertResponseValid(t, rr.Body, apiList.Entries)
 }
 
 func TestGetEntriesHandler(t *testing.T) {
@@ -69,6 +103,7 @@ func TestGetEntriesHandler(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	apiList.Entries = mockEntry()
 	rr := httptest.NewRecorder()
 	handler := getEntriesHandler()
 	handler.ServeHTTP(rr, req)
@@ -76,6 +111,7 @@ func TestGetEntriesHandler(t *testing.T) {
 		t.Errorf("handler returned wrong status code: got %v want %v",
 			status, http.StatusOK)
 	}
+	assertResponseValid(t, rr.Body, apiList.Entries)
 }
 
 func TestGetEntriesWithBadMethod(t *testing.T) {


### PR DESCRIPTION
Fixes issue #10. Along with allowing the /random endpoint to accept a
search request filter, we have done some unit test refactoring.